### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: :index
+  before_action :authenticate_user!, except: [:index, :show]
+
   def index
     @items = Item.order(id: 'DESC')
   end
@@ -18,9 +19,9 @@ class ItemsController < ApplicationController
     end
   end
 
-  # def show
-  #   @item = Item.find(params[:id])
-  # end
+  def show
+    @item = Item.find(params[:id])
+  end
 
   private
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,7 +131,7 @@
       <% if @items.present? %>
       <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "" do %>
+        <%= link_to item_path(item.id) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,67 +4,66 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%# <%= @item.item_name %> 
+      <%= @item.item_name %> 
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <%# <% unless item.present? %> 
+      <%= image_tag @item.image ,class:"item-box-img" %>
+
+      <% unless @item.present? %> 
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
-      <%# <% end %> 
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <% end %> 
+
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥<%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.ship_cost.name %>
       </span>
     </div>
+    <% if user_signed_in? %>
+      <% if current_user.id == @item.user_id %>
+        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+          <p class="or-text">or</p>
+        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+      <% else %>
+        <% if @item.present? %> 
+          <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+        <% end %>
+      <% end %>
+    <% end %>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.item_explanation %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <%# <td class="detail-value"><%= @item.user %></td> 
+          <td class="detail-value"><%= @item.user.nickname %></td> 
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <%# <td class="detail-value"><%= @item.category.name %></td> 
+          <td class="detail-value"><%= @item.category.name %></td> 
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <%# <td class="detail-value"><%= @item.product_condition.name %></td>
+          <td class="detail-value"><%= @item.product_condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <%# <td class="detail-value"><%= @item.ship_cost.name %></td>
+          <td class="detail-value"><%= @item.ship_cost.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <%# <td class="detail-value"><%= @item.prefecture.name %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <%# <td class="detail-value"><%= @item.ship_day.name %></td>
+          <td class="detail-value"><%= @item.ship_day.name %></td>
         </tr>
       </tbody>
     </table>
@@ -103,9 +102,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -9,11 +9,11 @@
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" %>
 
-      <% unless @item.present? %> 
+      <%# <% unless @item.present? %> 
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
-      <% end %> 
+      <%# <% end %> 
 
     </div>
     <div class="item-price-box">
@@ -30,9 +30,9 @@
           <p class="or-text">or</p>
         <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
       <% else %>
-        <% if @item.present? %> 
+      <%# 商品が売れていない場合はこちらを表示しましょう %>
           <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-        <% end %>
+      <%# //商品が売れていない場合はこちらを表示しましょう %>
       <% end %>
     <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create ]
+  resources :items, only: [:index, :new, :create, :show ]
 end


### PR DESCRIPTION
商品購入機能は未実装です。
レビューよろしくお願いいたします。

### What
フリマアプリでの商品詳細表示ページの実装
ログイン・ログアウト状態、自分が出品した商品かどうかでボタンの表示を変えました。

### Why

フリマアプリでユーザーの興味のある商品の詳細情報がわかり、購入するかどうか検討できるようにするため。

---
### Gyazo
-ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/f34798632c2e4c749ae05f69392d5658

-ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/4879fd77dc393947d58bbe14da7975f5

-ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/e2d5ef92378d28f256d701b887438085